### PR TITLE
Feature/scriptable object collection support for labelled parameters

### DIFF
--- a/Editor/Extensions/EditorParamRefExtensions.cs
+++ b/Editor/Extensions/EditorParamRefExtensions.cs
@@ -48,12 +48,8 @@ namespace RoyTheunissen.FMODSyntax
                     return parameter.HasNormalizedRange() ? "ParameterBool" : "ParameterInt";
                 case ParameterType.Labeled:
                 {
-                    string name = parameter.GetFilteredName();
-                    
-                    // First check if there's a user-specified type.
-                    
-
 #if SCRIPTABLE_OBJECT_COLLECTION
+                    string name = parameter.GetFilteredName();
                     bool hasUserType = FmodCodeGenerator.GetUserSpecifiedLabelParameterType(name, out Type userType);
                     if (hasUserType && !typeof(Enum).IsAssignableFrom(userType))
                         return $"ParameterScriptableObjectCollectionItem<{parameter.GetLabelParameterTypeName(false, null)}>";

--- a/Editor/FmodCodeGenerator.cs
+++ b/Editor/FmodCodeGenerator.cs
@@ -293,8 +293,7 @@ namespace RoyTheunissen.FMODSyntax
             GenerateCode();
         }
 #endif // FMOD_AUTO_REGENERATE_CODE
-
-        [MenuItem("FMOD/Cache Enums")]
+        
         private static void CacheUserSpecifiedLabelParameterTypes()
         {
             if (didCacheUserSpecifiedEnums)
@@ -303,20 +302,20 @@ namespace RoyTheunissen.FMODSyntax
             didCacheUserSpecifiedEnums = true;
             
             labelParameterNameToUserSpecifiedType.Clear();
-            Type[] enums = TypeExtensions.GetAllTypesWithAttribute<FmodLabelTypeAttribute>();
-            for (int i = 0; i < enums.Length; i++)
+            Type[] userSpecifiedTypes = TypeExtensions.GetAllTypesWithAttribute<FmodLabelTypeAttribute>();
+            for (int i = 0; i < userSpecifiedTypes.Length; i++)
             {
-                Type enumType = enums[i];
-                FmodLabelTypeAttribute attribute = enumType.GetAttribute<FmodLabelTypeAttribute>();
+                Type userSpecifiedType = userSpecifiedTypes[i];
+                FmodLabelTypeAttribute attribute = userSpecifiedType.GetAttribute<FmodLabelTypeAttribute>();
 
                 for (int j = 0; j < attribute.LabelledParameterNames.Length; j++)
                 {
                     string parameterName = attribute.LabelledParameterNames[j];
-                    bool succeeded = labelParameterNameToUserSpecifiedType.TryAdd(parameterName, enumType);
+                    bool succeeded = labelParameterNameToUserSpecifiedType.TryAdd(parameterName, userSpecifiedType);
                     if (!succeeded)
                     {
                         Type existingEnumType = labelParameterNameToUserSpecifiedType[parameterName];
-                        Debug.LogError($"Enum '{enumType.Name}' tried to map labelled parameters with name " +
+                        Debug.LogError($"Enum '{userSpecifiedType.Name}' tried to map labelled parameters with name " +
                                          $"'{parameterName}' via [FmodLabelType], but that was already mapped to " +
                                          $"type '{existingEnumType.Name}'. Make sure there is only one such mapping.");
                     }

--- a/Editor/FmodCodeGenerator.cs
+++ b/Editor/FmodCodeGenerator.cs
@@ -249,14 +249,14 @@ namespace RoyTheunissen.FMODSyntax
         
         private static Dictionary<string, string> detectedEventChanges = new Dictionary<string, string>();
         
-        [NonSerialized] private static readonly Dictionary<string, Type> labelParameterNameToUserSpecifiedEnumType 
+        [NonSerialized] private static readonly Dictionary<string, Type> labelParameterNameToUserSpecifiedType 
             = new Dictionary<string, Type>();
         [NonSerialized] private static bool didCacheUserSpecifiedEnums;
 
         [InitializeOnLoadMethod]
         private static void Initialize()
         {
-            labelParameterNameToUserSpecifiedEnumType.Clear();
+            labelParameterNameToUserSpecifiedType.Clear();
             didCacheUserSpecifiedEnums = false;
 
             // NOTE: For this to work, SourceFilesChangedEvent and BankRefreshEvent events need to be added to FMOD.
@@ -295,40 +295,40 @@ namespace RoyTheunissen.FMODSyntax
 #endif // FMOD_AUTO_REGENERATE_CODE
 
         [MenuItem("FMOD/Cache Enums")]
-        private static void CacheUserSpecifiedLabelParameterEnums()
+        private static void CacheUserSpecifiedLabelParameterTypes()
         {
             if (didCacheUserSpecifiedEnums)
                 return;
 
             didCacheUserSpecifiedEnums = true;
             
-            labelParameterNameToUserSpecifiedEnumType.Clear();
-            Type[] enums = TypeExtensions.GetAllTypesWithAttribute<FmodLabelEnumAttribute>();
+            labelParameterNameToUserSpecifiedType.Clear();
+            Type[] enums = TypeExtensions.GetAllTypesWithAttribute<FmodLabelTypeAttribute>();
             for (int i = 0; i < enums.Length; i++)
             {
                 Type enumType = enums[i];
-                FmodLabelEnumAttribute attribute = enumType.GetAttribute<FmodLabelEnumAttribute>();
+                FmodLabelTypeAttribute attribute = enumType.GetAttribute<FmodLabelTypeAttribute>();
 
                 for (int j = 0; j < attribute.LabelledParameterNames.Length; j++)
                 {
                     string parameterName = attribute.LabelledParameterNames[j];
-                    bool succeeded = labelParameterNameToUserSpecifiedEnumType.TryAdd(parameterName, enumType);
+                    bool succeeded = labelParameterNameToUserSpecifiedType.TryAdd(parameterName, enumType);
                     if (!succeeded)
                     {
-                        Type existingEnumType = labelParameterNameToUserSpecifiedEnumType[parameterName];
+                        Type existingEnumType = labelParameterNameToUserSpecifiedType[parameterName];
                         Debug.LogError($"Enum '{enumType.Name}' tried to map labelled parameters with name " +
-                                         $"'{parameterName}' via [FmodLabelEnum], but that was already mapped to " +
-                                         $"enum '{existingEnumType.Name}'. Make sure there is only one such mapping.");
+                                         $"'{parameterName}' via [FmodLabelType], but that was already mapped to " +
+                                         $"type '{existingEnumType.Name}'. Make sure there is only one such mapping.");
                     }
                 }
             }
         }
 
-        public static bool GetUserSpecifiedLabelParameterEnum(string name, out Type enumType)
+        public static bool GetUserSpecifiedLabelParameterType(string name, out Type enumType)
         {
-            CacheUserSpecifiedLabelParameterEnums();
+            CacheUserSpecifiedLabelParameterTypes();
             
-            return labelParameterNameToUserSpecifiedEnumType.TryGetValue(name, out enumType);
+            return labelParameterNameToUserSpecifiedType.TryGetValue(name, out enumType);
         }
 
         private static string GetParameterCode(CodeGenerator codeGenerator, EditorParamRef parameter)
@@ -347,7 +347,7 @@ namespace RoyTheunissen.FMODSyntax
             const string enumKeyword = "ParameterEnum";
             if (parameter.Type == ParameterType.Labeled)
             {
-                bool hasUserSpecifiedEnum = GetUserSpecifiedLabelParameterEnum(parameter.Name, out Type enumType);
+                bool hasUserSpecifiedEnum = GetUserSpecifiedLabelParameterType(parameter.Name, out Type enumType);
                 if (hasUserSpecifiedEnum)
                 {
                     // Not generating a new enum.

--- a/Editor/RoyTheunissen.FMODSyntax.Editor.asmdef
+++ b/Editor/RoyTheunissen.FMODSyntax.Editor.asmdef
@@ -15,6 +15,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.brunomikoski.scriptableobjectcollection",
+            "expression": "2.2.1",
+            "define": "SCRIPTABLE_OBJECT_COLLECTION"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ AudioEvents.Jump.Play(transform, JumpPlayback.SurfaceValues.Generic);
 
 Furthermore, the enums in FMOD may actually represent an enum in your game. So it's inconvenient to have to map from that game enum to the FMOD enum. But there's a solution for that: **User-specified labeled parameter enums**.
 
-Simply tag your game enum with `[FmodLabelEnum]` and specify the names of the labeled parameters that it represents, and then when code is generated instead of generating event-specific enums, it uses the game enum you specified for those events.
+Simply tag your game enum with `[FmodLabelType]` and specify the names of the labeled parameters that it represents, and then when code is generated instead of generating event-specific enums, it uses the game enum you specified for those events.
 
 No more duplication, no more mapping.
 
 ```cs
-[FmodLabelEnum("Surface")]
+[FmodLabelType("Surface")]
 public enum SurfaceTypes
 {
     Generic,
@@ -121,6 +121,13 @@ public enum SurfaceTypes
 AudioEvents.Footstep.Play(transform, SurfaceTypes.Generic);
 AudioEvents.Jump.Play(transform, SurfaceTypes.Generic);
 ```
+#### Scriptable Object Collection Support
+
+The above 'Labeled parameter enums' feature now also works for the [Scriptable Object Collection](https://github.com/brunomikoski/ScriptableObjectCollection). Simply add the `[FmodLabelType]` attribute to the Scriptable Object Collection Item the same way you would with an enum.
+
+_**NOTE:** If you installed FMOD-Syntax or ScriptableObjectCollection to the `Assets` folder instead of via the Package Manager / in the Packages folder, a `SCRIPTABLE_OBJECT_COLLECTION` scripting define symbol will not be defined automatically and you will have to manually add this to the project settings for this feature to work._
+
+
 
 ### Moving/renaming Events
 FMOD-Syntax has a two-tiered solution for allowing you to move/rename events in FMOD and update your code accordingly:

--- a/Runtime/Events/Parameter.cs
+++ b/Runtime/Events/Parameter.cs
@@ -2,6 +2,10 @@ using System;
 using FMOD.Studio;
 using FMODUnity;
 
+#if SCRIPTABLE_OBJECT_COLLECTION
+using BrunoMikoski.ScriptableObjectCollections;
+#endif // SCRIPTABLE_OBJECT_COLLECTION
+
 namespace RoyTheunissen.FMODSyntax
 {
     /// <summary>
@@ -109,6 +113,26 @@ namespace RoyTheunissen.FMODSyntax
             return (int)(object)value;
         }
     }
+    
+#if SCRIPTABLE_OBJECT_COLLECTION
+    public sealed class ParameterScriptableObjectCollectionItem<ItemType> : ParameterGeneric<ItemType>
+        where ItemType : ScriptableObjectCollectionItem
+    {
+        public ParameterScriptableObjectCollectionItem(PARAMETER_ID id, bool isGlobal) : base(id, isGlobal)
+        {
+        }
+
+        protected override ItemType GetValueFromFloat(float value)
+        {
+            return ScriptableObjectCollection<ItemType>.Values[(int)value];
+        }
+
+        protected override float GetFloatFromValue(ItemType value)
+        {
+            return value.Index;
+        }
+    }
+#endif // SCRIPTABLE_OBJECT_COLLECTION
     
     public sealed class ParameterBool : ParameterGeneric<bool>
     {

--- a/Runtime/FmodLabelEnum.cs
+++ b/Runtime/FmodLabelEnum.cs
@@ -3,18 +3,28 @@ using System;
 namespace RoyTheunissen.FMODSyntax
 {
     /// <summary>
-    /// Attribute to let the FMOD Syntax system know that a custom enum is used to represent a labelled parameter.
+    /// Attribute to let the FMOD Syntax system know that a custom type is used to represent a labelled parameter.
     /// This is useful if for example you have a labelled parameter that is shared between various events, and you want
-    /// to have only one enum represent it instead of having to map enums back-and-forth. 
+    /// to have only one enum represent it instead of having to map enums back-and-forth. Instead of an enum you can now
+    /// also use a Scriptable Object Collection item.
     /// </summary>
-    public class FmodLabelEnumAttribute : Attribute
+    public class FmodLabelTypeAttribute : Attribute
     {
         private string[] labelledParameterNames;
         public string[] LabelledParameterNames => labelledParameterNames;
 
-        public FmodLabelEnumAttribute(params string[] labelledParameterNames)
+        public FmodLabelTypeAttribute(params string[] labelledParameterNames)
         {
             this.labelledParameterNames = labelledParameterNames;
         }
+    }
+    
+    /// <summary>
+    /// Basically here for backwards compatibility. FmodLabelTypeAttribute is a better name because these days it also
+    /// supports linking Scriptable Object Collection item types to an FMOD Label parameter. I find it a bit harsh
+    /// to mark this one as obsolete though, seems harmless to make this one just redirect to FmodLabelTypeAttribute.
+    /// </summary>
+    public sealed class FmodLabelEnumAttribute : FmodLabelTypeAttribute
+    {
     }
 }

--- a/Runtime/RoyTheunissen.FMODSyntax.asmdef
+++ b/Runtime/RoyTheunissen.FMODSyntax.asmdef
@@ -2,7 +2,8 @@
     "name": "RoyTheunissen.FMODSyntax",
     "rootNamespace": "RoyTheunissen.FMODSyntax",
     "references": [
-        "GUID:0c752da273b17c547ae705acf0f2adf2"
+        "GUID:0c752da273b17c547ae705acf0f2adf2",
+        "GUID:435719c11c6f941d98c6110929b03789"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Runtime/RoyTheunissen.FMODSyntax.asmdef
+++ b/Runtime/RoyTheunissen.FMODSyntax.asmdef
@@ -2,8 +2,8 @@
     "name": "RoyTheunissen.FMODSyntax",
     "rootNamespace": "RoyTheunissen.FMODSyntax",
     "references": [
-        "GUID:0c752da273b17c547ae705acf0f2adf2",
-        "GUID:435719c11c6f941d98c6110929b03789"
+        "FMODUnity",
+        "BrunoMikoski.ScriptableObjectCollection"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -12,6 +12,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.brunomikoski.scriptableobjectcollection",
+            "expression": "2.2.1",
+            "define": "SCRIPTABLE_OBJECT_COLLECTION"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
- Renamed `[FmodLabelEnum]` to `[FmodLabelType]`. The old name is still valid, just introducing the new name because it's more accurate now that it supports types other than enums.
- You can now put an `[FmodLabelType]` attribute on [Scriptable Object Collection](https://github.com/brunomikoski/ScriptableObjectCollection) items too.