### PR TITLE
Add Fluent Paramters Implementation

### DIFF
--- a/Scripts/Runtime/Common/IAudioPlaybackExtensions.cs
+++ b/Scripts/Runtime/Common/IAudioPlaybackExtensions.cs
@@ -1,0 +1,72 @@
+﻿using System;
+
+namespace RoyTheunissen.AudioSyntax
+{
+    public static class IAudioPlaybackExtensions
+    {
+        public static IAudioPlayback WithParameter(this IAudioPlayback playback,
+            string name, float value, bool ignoreSeekSpeed = false)
+        {
+#if FMOD_AUDIO_SYNTAX
+            if (playback is FmodAudioPlayback fmod)
+                fmod.SetParameter(name, value, ignoreSeekSpeed);
+#endif
+            return playback;
+        }
+
+        public static IAudioPlayback WithParameter(this IAudioPlayback playback,
+            string name, int value, bool ignoreSeekSpeed = false)
+        {
+#if FMOD_AUDIO_SYNTAX
+            if (playback is FmodAudioPlayback fmod)
+                fmod.SetParameter(name, value, ignoreSeekSpeed);
+#endif
+            return playback;
+        }
+
+        public static IAudioPlayback WithParameter(this IAudioPlayback playback,
+            string name, bool value, bool ignoreSeekSpeed = false)
+        {
+#if FMOD_AUDIO_SYNTAX
+            if (playback is FmodAudioPlayback fmod)
+                fmod.SetParameter(name, value ? 1f : 0f, ignoreSeekSpeed);
+#endif
+            return playback;
+        }
+
+        public static IAudioPlayback WithParameterLabel(this IAudioPlayback playback,
+            string name, string label, bool ignoreSeekSpeed = false)
+        {
+#if FMOD_AUDIO_SYNTAX
+            if (playback is FmodAudioPlayback fmod)
+                fmod.SetParameterLabel(name, label, ignoreSeekSpeed);
+#endif
+            return playback;
+        }
+
+        public static IAudioPlayback WithParameter<TEnum>(this IAudioPlayback playback,
+            string name, TEnum value, bool ignoreSeekSpeed = false)
+            where TEnum : struct, Enum
+        {
+#if FMOD_AUDIO_SYNTAX
+            if (playback is FmodAudioPlayback fmod)
+                fmod.SetParameter(name, Convert.ToInt32(value), ignoreSeekSpeed);
+#endif
+            return playback;
+        }
+
+        public static IAudioPlayback WithParameters(this IAudioPlayback playback,
+            params (string name, float value)[] parameters)
+        {
+            for (int i = 0; i < parameters.Length; i++)
+                playback.WithParameter(parameters[i].name, parameters[i].value);
+            return playback;
+        }
+
+        public static IAudioPlayback WithVolume(this IAudioPlayback playback, float volume)
+        {
+            playback.Volume = volume;
+            return playback;
+        }
+    }
+}

--- a/Scripts/Runtime/Common/IAudioPlaybackExtensions.cs
+++ b/Scripts/Runtime/Common/IAudioPlaybackExtensions.cs
@@ -1,72 +1,70 @@
 ﻿using System;
 
+#if FMOD_AUDIO_SYNTAX
 namespace RoyTheunissen.AudioSyntax
 {
     public static class IAudioPlaybackExtensions
     {
-        public static IAudioPlayback WithParameter(this IAudioPlayback playback,
+        public static IAudioPlayback SetParameter(this IAudioPlayback playback,
             string name, float value, bool ignoreSeekSpeed = false)
         {
-#if FMOD_AUDIO_SYNTAX
             if (playback is FmodAudioPlayback fmod)
                 fmod.SetParameter(name, value, ignoreSeekSpeed);
-#endif
+
             return playback;
         }
 
-        public static IAudioPlayback WithParameter(this IAudioPlayback playback,
+        public static IAudioPlayback SetParameter(this IAudioPlayback playback,
             string name, int value, bool ignoreSeekSpeed = false)
         {
-#if FMOD_AUDIO_SYNTAX
             if (playback is FmodAudioPlayback fmod)
                 fmod.SetParameter(name, value, ignoreSeekSpeed);
-#endif
+
             return playback;
         }
 
-        public static IAudioPlayback WithParameter(this IAudioPlayback playback,
+        public static IAudioPlayback SetParameter(this IAudioPlayback playback,
             string name, bool value, bool ignoreSeekSpeed = false)
         {
-#if FMOD_AUDIO_SYNTAX
             if (playback is FmodAudioPlayback fmod)
                 fmod.SetParameter(name, value ? 1f : 0f, ignoreSeekSpeed);
-#endif
+
             return playback;
         }
 
-        public static IAudioPlayback WithParameterLabel(this IAudioPlayback playback,
+        public static IAudioPlayback SetParameterLabel(this IAudioPlayback playback,
             string name, string label, bool ignoreSeekSpeed = false)
         {
-#if FMOD_AUDIO_SYNTAX
             if (playback is FmodAudioPlayback fmod)
                 fmod.SetParameterLabel(name, label, ignoreSeekSpeed);
-#endif
+
             return playback;
         }
 
-        public static IAudioPlayback WithParameter<TEnum>(this IAudioPlayback playback,
+        public static IAudioPlayback SetParameter<TEnum>(this IAudioPlayback playback,
             string name, TEnum value, bool ignoreSeekSpeed = false)
             where TEnum : struct, Enum
         {
-#if FMOD_AUDIO_SYNTAX
             if (playback is FmodAudioPlayback fmod)
                 fmod.SetParameter(name, Convert.ToInt32(value), ignoreSeekSpeed);
-#endif
+
             return playback;
         }
 
-        public static IAudioPlayback WithParameters(this IAudioPlayback playback,
+        public static IAudioPlayback SetParameters(this IAudioPlayback playback,
             params (string name, float value)[] parameters)
         {
             for (int i = 0; i < parameters.Length; i++)
-                playback.WithParameter(parameters[i].name, parameters[i].value);
+                playback.SetParameter(parameters[i].name, parameters[i].value);
             return playback;
         }
 
-        public static IAudioPlayback WithVolume(this IAudioPlayback playback, float volume)
+        public static IAudioPlayback SetVolume(this IAudioPlayback playback, float volume)
         {
             playback.Volume = volume;
             return playback;
         }
     }
 }
+#endif
+

--- a/Scripts/Runtime/Common/IAudioPlaybackExtensions.cs.meta
+++ b/Scripts/Runtime/Common/IAudioPlaybackExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 62082dfd70f44e67b80f03501890dc73
+timeCreated: 1761601697

--- a/Scripts/Runtime/FMOD/Events/FmodAudioPlayback.cs
+++ b/Scripts/Runtime/FMOD/Events/FmodAudioPlayback.cs
@@ -262,6 +262,27 @@ namespace RoyTheunissen.AudioSyntax
 
             return this;
         }
+        
+        public FmodAudioPlayback SetParameter(string name, float value, bool ignoreSeekSpeed = false)
+        {
+            if (Instance.isValid())
+                Instance.setParameterByName(name, value, ignoreSeekSpeed);
+            return this;
+        }
+
+        public FmodAudioPlayback SetParameter(PARAMETER_ID id, float value, bool ignoreSeekSpeed = false)
+        {
+            if (Instance.isValid())
+                Instance.setParameterByID(id, value, ignoreSeekSpeed);
+            return this;
+        }
+
+        public FmodAudioPlayback SetParameterLabel(string name, string label, bool ignoreSeekSpeed = false)
+        {
+            if (Instance.isValid())
+                Instance.setParameterByNameWithLabel(name, label, ignoreSeekSpeed);
+            return this;
+        }
     }
 }
 


### PR DESCRIPTION
With this even when using `AudioReference` we can still set parameters.

For instance like this:

```
[SerializeField] 
private AudioReference _collisionSfx;

private void OnCollisionEnter(Collision collision)
{
    if (collision.impulse.magnitude > _collisionSfxThreshold)
    {
        if (Time.time - _lastCollisionSfxTime < _collisionSfxCooldown)
            return;

        float volume = collision.impulse.magnitude * _collisionSfxMagnitudeMultiplier;
        if (!_collisionSfx.IsAssigned)
        {
            AudioEvents.Objects.ObjectHit.Play(transform, volume);
        }
        else
        {
            _collisionSfx.Play(transform).WithParameter("volume", volume);
        }
        _lastCollisionSfxTime = Time.time;
    }
}
```