### PR TITLE
Resolve ambiguity between FMOD.GUID and UnityEngine.GUID

### DIFF
--- a/Runtime/Events/FmodAudioPlayback.cs
+++ b/Runtime/Events/FmodAudioPlayback.cs
@@ -100,7 +100,7 @@ namespace RoyTheunissen.FMODSyntax
             
             if (!eventDescription.isValid())
             {
-                eventDescription.getID(out GUID guid);
+                eventDescription.getID(out FMOD.GUID guid);
                 Debug.LogError($"Trying to play invalid FMOD Event guid: '{guid}' path:'{path}'");
                 return;
             }


### PR DESCRIPTION
In Unity 6000.4.0f1 this line produces an error because it doesn't know which GUID type to use